### PR TITLE
Implement UVarInt as a struct

### DIFF
--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -185,4 +185,123 @@ describe UVarInt do
       end
     end
   end
+
+  describe "math operators" do
+    it "%" do
+      a = UVarInt.new 5_u8
+      b = UVarInt.new 2_u8
+      c = UVarInt.new 1_u8
+      (a % b).should eq(c)
+    end
+
+    it "&" do
+      a = UVarInt.new 4_u8
+      b = UVarInt.new 3_u8
+      c = UVarInt.new 0_u8
+      (a & b).should eq(c)
+    end
+
+    it "*" do
+      a = UVarInt.new 4_u8
+      b = UVarInt.new 5_u8
+      c = UVarInt.new 20_u8
+      (a * b).should eq(c)
+    end
+
+    it "**" do
+      a = UVarInt.new 2_u8
+      b = UVarInt.new 4_u8
+      c = UVarInt.new 16_u8
+      (a ** b).should eq(c)
+    end
+
+    it "+" do
+      a = UVarInt.new 2_u8
+      b = UVarInt.new 4_u8
+      c = UVarInt.new 6_u8
+      (a + b).should eq(c)
+    end
+
+    it "-" do
+      a = UVarInt.new 4_u8
+      b = UVarInt.new 3_u8
+      c = UVarInt.new 1_u8
+      (a - b).should eq(c)
+    end
+
+    it "/" do
+      a = UVarInt.new 8_u8
+      b = UVarInt.new 4_u8
+      c = UVarInt.new 2_u8
+      (a / b).should eq(c)
+    end
+
+    it "<<" do
+      a = UVarInt.new 2_u8
+      b = UVarInt.new 3_u8
+      c = UVarInt.new 16_u8
+      (a << b).should eq(c)
+    end
+
+    it ">>" do
+      a = UVarInt.new 16_u8
+      b = UVarInt.new 3_u8
+      c = UVarInt.new 2_u8
+      (a >> b).should eq(c)
+    end
+
+    it "^" do
+      a = UVarInt.new 4_u8
+      b = UVarInt.new 3_u8
+      c = UVarInt.new 7_u8
+      (a ^ b).should eq(c)
+    end
+  end
+
+  describe "logic operators" do
+    it "<" do
+      a = UVarInt.new 1_u8
+      b = UVarInt.new 2_u8
+      (a < b).should eq(true)
+      (b < a).should eq(false)
+    end
+
+    it "<=" do
+      a = UVarInt.new 1_u8
+      b = UVarInt.new 2_u8
+      (a <= a).should eq(true)
+      (a <= b).should eq(true)
+      (b <= a).should eq(false)
+    end
+
+    it "<=>" do
+      a = UVarInt.new 1_u8
+      b = UVarInt.new 2_u8
+      (a <=> b).should eq(-1)
+      (b <=> a).should eq(1)
+      (a <=> a).should eq(0)
+    end
+
+    it "==" do
+      a = UVarInt.new 1_u8
+      b = UVarInt.new 2_u8
+      (a == a).should eq(true)
+      (a == b).should eq(false)
+    end
+
+    it ">" do
+      a = UVarInt.new 1_u8
+      b = UVarInt.new 2_u8
+      (b > a).should eq(true)
+      (a > b).should eq(false)
+    end
+
+    it ">=" do
+      a = UVarInt.new 1_u8
+      b = UVarInt.new 2_u8
+      (a >= a).should eq(true)
+      (b >= a).should eq(true)
+      (a >= b).should eq(false)
+    end
+  end
 end

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -1,4 +1,6 @@
+require "big/big_int"
 require "spec"
+
 require "../src/uvarint"
 
 describe UVarInt do
@@ -25,6 +27,12 @@ describe UVarInt do
       v = UVarInt.new 5000000000_u64
       b = v.bytes
       b.should eq(Bytes[128, 228, 151, 208, 18])
+    end
+
+    it "handles bigints" do
+      v = UVarInt.new(BigInt.new "9999999999999999999999999999999999")
+      b = v.bytes
+      b.should eq(Bytes[255, 255, 255, 255, 191, 204, 227, 198, 183, 128, 159, 236, 234, 183, 194, 246, 1])
     end
 
     it "handles arrays" do
@@ -68,20 +76,9 @@ describe UVarInt do
       u = v.uint
       u.should eq(97)
     end
-
-    it "raises an exception if passed more than 10 bytes" do
-      b = Array.new(20, 0_u8)
-      ex = expect_raises(ArgumentError) { UVarInt.new b }
-      ex.message.should eq("cannot initialize with more than 10 bytes")
-    end
   end
 
   describe "[] macro" do
-    it "throws if more than 10 bytes are passed" do
-      ex = expect_raises(ArgumentError) { UVarInt[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
-      ex.message.should eq("cannot initialize with more than 10 bytes")
-    end
-
     it "instantiates a UVarInt with the passed bytes" do
       v = UVarInt[172, 2]
       b = v.bytes
@@ -161,7 +158,7 @@ describe UVarInt do
       end
     end
 
-    it "encodes and decodes big integers" do
+    it "encodes and decodes uint64 values" do
       bigs = [] of UInt64
       (32..53).each do |i|
         n = (2 ** i).to_u64
@@ -176,7 +173,7 @@ describe UVarInt do
       end
     end
 
-    it "encodes and decodes really big integers" do
+    it "encodes and decodes large uint64 values" do
       max_u32 = 0_u32..0xFFFFFFFF_u32
       (0..100000).each do
         upper = Random.rand(max_u32).to_u64 << 32

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -76,6 +76,19 @@ describe UVarInt do
     end
   end
 
+  describe "[] macro" do
+    it "throws if more than 10 bytes are passed" do
+      ex = expect_raises(ArgumentError) { UVarInt[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+      ex.message.should eq("cannot initialize with more than 10 bytes")
+    end
+
+    it "instantiates a UVarInt with the passed bytes" do
+      v = UVarInt[172, 2]
+      b = v.bytes
+      b.should eq(Bytes[172, 2])
+    end
+  end
+
   describe "decode" do
     it "decodes single bytes" do
       n = Random.rand(0..0x7F).to_u8
@@ -119,6 +132,22 @@ describe UVarInt do
       v = UVarInt.new 0x0F00_u64
       b = v.bytes
       b.should eq(Bytes[0x80_u8, 0x1E_u8])
+    end
+  end
+
+  describe "to_s" do
+    it "returns self.uint.to_s" do
+      v = UVarInt.new 300_u64
+      s = v.to_s 16
+      s.should eq("12c")
+    end
+  end
+
+  describe "hexstring" do
+    it "returns self.bytes.hexstring" do
+      v = UVarInt.new 300_u64
+      h = v.hexstring
+      h.should eq("ac02")
     end
   end
 

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -2,6 +2,112 @@ require "spec"
 require "../src/uvarint"
 
 describe UVarInt do
+  describe "instantiate" do
+    it "handles uint8" do
+      v = UVarInt.new 64_u8
+      e = v.encoded
+      e.should eq(Bytes[64])
+    end
+
+    it "handles uint16" do
+      v = UVarInt.new 300_u16
+      e = v.encoded
+      e.should eq(Bytes[172, 2])
+    end
+
+    it "handles uint32" do
+      v = UVarInt.new 70000_u32
+      e = v.encoded
+      e.should eq(Bytes[240, 162, 4])
+    end
+
+    it "handles uint64" do
+      v = UVarInt.new 5000000000_u64
+      e = v.encoded
+      e.should eq(Bytes[128, 228, 151, 208, 18])
+    end
+
+    it "handles arrays" do
+      a = [0xAC_u8, 0x02_u8]
+      v = UVarInt.new a
+      d = v.decoded
+      d.should eq(300)
+    end
+
+    it "handles deques" do
+      d = Deque{0xAC_u8, 0x02_u8}
+      v = UVarInt.new d
+      d = v.decoded
+      d.should eq(300)
+    end
+
+    it "handles static arrays" do
+      s = StaticArray[0xAC_u8, 0x02_u8]
+      v = UVarInt.new s
+      d = v.decoded
+      d.should eq(300)
+    end
+
+    it "handles tuples" do
+      t = {0xAC_u8, 0x02_u8}
+      v = UVarInt.new t
+      d = v.decoded
+      d.should eq(300)
+    end
+
+    it "raises an exception if passed more than 10 bytes" do
+      b = Array.new(20, 0_u8)
+      ex = expect_raises(ArgumentError) { UVarInt.new b }
+      ex.message.should eq("cannot initialize with more than 10 bytes")
+    end
+  end
+
+  describe "decode" do
+    it "decodes single bytes" do
+      n = Random.rand(0..0x7F).to_u8
+      b = Bytes[n]
+      v = UVarInt.new b
+      d = v.decoded
+      d.should eq(n)
+    end
+
+    it "decodes multiple bytes" do
+      b = Bytes[0xAC_u8, 0x02_u8]
+      v = UVarInt.new b
+      d = v.decoded
+      d.should eq(300)
+    end
+
+    it "decodes multiple bytes with zero" do
+      n = Random.rand(0x7F).to_u8
+      b = Bytes[0x80_u8, n]
+      v = UVarInt.new b
+      d = v.decoded
+      d.should eq(n.to_u64 << 7)
+    end
+  end
+
+  describe "encode" do
+    it "encodes to single bytes" do
+      n = Random.rand(0x7F).to_u64
+      v = UVarInt.new n
+      e = v.encoded
+      e.should eq(Bytes[n.to_u8])
+    end
+
+    it "encodes to multiple bytes" do
+      v = UVarInt.new 300_u64
+      e = v.encoded
+      e.should eq(Bytes[0xAC_u8, 0x02_u8])
+    end
+
+    it "encodes to multiple bytes with first byte zero" do
+      v = UVarInt.new 0x0F00_u64
+      e = v.encoded
+      e.should eq(Bytes[0x80_u8, 0x1E_u8])
+    end
+  end
+
   it "encodes and decodes random values" do
     (0..100000).each do
       n = Random.rand(0..0x7FFFFFFF).to_u64
@@ -9,48 +115,6 @@ describe UVarInt do
       d = v.decoded
       d.should eq(n)
     end
-  end
-
-  it "decodes single bytes" do
-    n = Random.rand(0..0x7F).to_u8
-    buf = [n]
-    v = UVarInt.new buf
-    d = v.decoded
-    d.should eq(n)
-  end
-
-  it "decodes multiple bytes" do
-    buf = [0xAC_u8, 0x02_u8]
-    v = UVarInt.new buf
-    d = v.decoded
-    d.should eq(300)
-  end
-
-  it "decodes multiple bytes with zero" do
-    n = Random.rand(0x7F).to_u8
-    buf = [0x80_u8, n]
-    v = UVarInt.new buf
-    d = v.decoded
-    d.should eq(n.to_u64 << 7)
-  end
-
-  it "encodes to single bytes" do
-    n = Random.rand(0x7F).to_u64
-    v = UVarInt.new n
-    e = v.encoded
-    e.should eq(Bytes[n.to_u8])
-  end
-
-  it "encodes to multiple bytes" do
-    v = UVarInt.new 300_u64
-    e = v.encoded
-    e.should eq(Bytes[0xAC_u8, 0x02_u8])
-  end
-
-  it "encodes to multiple bytes with first byte zero" do
-    v = UVarInt.new 0x0F00_u64
-    e = v.encoded
-    e.should eq(Bytes[0x80_u8, 0x1E_u8])
   end
 
   it "encodes and decodes big integers" do

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -1,12 +1,12 @@
 require "spec"
 require "../src/uvarint"
 
-describe UVarint do
+describe UVarInt do
   it "encodes and decodes random values" do
     (0..100000).each do
       n = Random.rand(0..0x7FFFFFFF).to_u64
-      e = UVarint.encode n
-      d = UVarint.decode e
+      v = UVarInt.new n
+      d = v.decoded
       d.should eq(n)
     end
   end
@@ -14,38 +14,43 @@ describe UVarint do
   it "decodes single bytes" do
     n = Random.rand(0..0x7F).to_u8
     buf = [n]
-    d = UVarint.decode buf
+    v = UVarInt.new buf
+    d = v.decoded
     d.should eq(n)
   end
 
   it "decodes multiple bytes" do
     buf = [0xAC_u8, 0x02_u8]
-    d = UVarint.decode buf
+    v = UVarInt.new buf
+    d = v.decoded
     d.should eq(300)
   end
 
   it "decodes multiple bytes with zero" do
     n = Random.rand(0x7F).to_u8
     buf = [0x80_u8, n]
-    d = UVarint.decode buf
+    v = UVarInt.new buf
+    d = v.decoded
     d.should eq(n.to_u64 << 7)
   end
 
   it "encodes to single bytes" do
     n = Random.rand(0x7F).to_u64
-    e = UVarint.encode n
-    e.should eq([n.to_u8])
+    v = UVarInt.new n
+    e = v.encoded
+    e.should eq(Bytes[n.to_u8])
   end
 
   it "encodes to multiple bytes" do
-    e = UVarint.encode 300_u64
-    e.should eq([0xAC_u8, 0x02_u8])
+    v = UVarInt.new 300_u64
+    e = v.encoded
+    e.should eq(Bytes[0xAC_u8, 0x02_u8])
   end
 
   it "encodes to multiple bytes with first byte zero" do
-    n = 0x0F00_u64
-    e = UVarint.encode n
-    e.should eq([0x80_u8, 0x1E_u8])
+    v = UVarInt.new 0x0F00_u64
+    e = v.encoded
+    e.should eq(Bytes[0x80_u8, 0x1E_u8])
   end
 
   it "encodes and decodes big integers" do
@@ -57,8 +62,8 @@ describe UVarint do
     end
 
     bigs.each do |n|
-      e = UVarint.encode n
-      d = UVarint.decode e
+      v = UVarInt.new n
+      d = v.decoded
       d.should eq(n)
     end
   end
@@ -69,8 +74,8 @@ describe UVarint do
       upper = Random.rand(max_u32).to_u64 << 32
       lower = Random.rand(max_u32).to_u64
       n = upper + lower
-      e = UVarint.encode n
-      d = UVarint.decode e
+      v = UVarInt.new n
+      d = v.decoded
       d.should eq(n)
     end
   end

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -55,6 +55,20 @@ describe UVarInt do
       d.should eq(300)
     end
 
+    it "handles ranges" do
+      r = 0x00_u8..0x09_u8
+      v = UVarInt.new r
+      d = v.decoded
+      d.should eq(0)
+    end
+
+    it "handles strings" do
+      s = "abcd"
+      v = UVarInt.new s
+      d = v.decoded
+      d.should eq(97)
+    end
+
     it "raises an exception if passed more than 10 bytes" do
       b = Array.new(20, 0_u8)
       ex = expect_raises(ArgumentError) { UVarInt.new b }

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -5,68 +5,68 @@ describe UVarInt do
   describe "instantiate" do
     it "handles uint8" do
       v = UVarInt.new 64_u8
-      e = v.encoded
-      e.should eq(Bytes[64])
+      b = v.bytes
+      b.should eq(Bytes[64])
     end
 
     it "handles uint16" do
       v = UVarInt.new 300_u16
-      e = v.encoded
-      e.should eq(Bytes[172, 2])
+      b = v.bytes
+      b.should eq(Bytes[172, 2])
     end
 
     it "handles uint32" do
       v = UVarInt.new 70000_u32
-      e = v.encoded
-      e.should eq(Bytes[240, 162, 4])
+      b = v.bytes
+      b.should eq(Bytes[240, 162, 4])
     end
 
     it "handles uint64" do
       v = UVarInt.new 5000000000_u64
-      e = v.encoded
-      e.should eq(Bytes[128, 228, 151, 208, 18])
+      b = v.bytes
+      b.should eq(Bytes[128, 228, 151, 208, 18])
     end
 
     it "handles arrays" do
       a = [0xAC_u8, 0x02_u8]
       v = UVarInt.new a
-      d = v.decoded
-      d.should eq(300)
+      u = v.uint
+      u.should eq(300)
     end
 
     it "handles deques" do
       d = Deque{0xAC_u8, 0x02_u8}
       v = UVarInt.new d
-      d = v.decoded
-      d.should eq(300)
+      u = v.uint
+      u.should eq(300)
     end
 
     it "handles static arrays" do
       s = StaticArray[0xAC_u8, 0x02_u8]
       v = UVarInt.new s
-      d = v.decoded
-      d.should eq(300)
+      u = v.uint
+      u.should eq(300)
     end
 
     it "handles tuples" do
       t = {0xAC_u8, 0x02_u8}
       v = UVarInt.new t
-      d = v.decoded
-      d.should eq(300)
+      u = v.uint
+      u.should eq(300)
     end
 
     it "handles ranges" do
       r = 0x00_u8..0x09_u8
       v = UVarInt.new r
-      d = v.decoded
-      d.should eq(0)
+      u = v.uint
+      u.should eq(0)
     end
 
     it "handles strings" do
       s = "abcd"
       v = UVarInt.new s
-      d = v.decoded
-      d.should eq(97)
+      u = v.uint
+      u.should eq(97)
     end
 
     it "raises an exception if passed more than 10 bytes" do
@@ -81,23 +81,23 @@ describe UVarInt do
       n = Random.rand(0..0x7F).to_u8
       b = Bytes[n]
       v = UVarInt.new b
-      d = v.decoded
-      d.should eq(n)
+      u = v.uint
+      u.should eq(n)
     end
 
     it "decodes multiple bytes" do
       b = Bytes[0xAC_u8, 0x02_u8]
       v = UVarInt.new b
-      d = v.decoded
-      d.should eq(300)
+      u = v.uint
+      u.should eq(300)
     end
 
     it "decodes multiple bytes with zero" do
       n = Random.rand(0x7F).to_u8
       b = Bytes[0x80_u8, n]
       v = UVarInt.new b
-      d = v.decoded
-      d.should eq(n.to_u64 << 7)
+      u = v.uint
+      u.should eq(n.to_u64 << 7)
     end
   end
 
@@ -105,20 +105,20 @@ describe UVarInt do
     it "encodes to single bytes" do
       n = Random.rand(0x7F).to_u64
       v = UVarInt.new n
-      e = v.encoded
-      e.should eq(Bytes[n.to_u8])
+      b = v.bytes
+      b.should eq(Bytes[n.to_u8])
     end
 
     it "encodes to multiple bytes" do
       v = UVarInt.new 300_u64
-      e = v.encoded
-      e.should eq(Bytes[0xAC_u8, 0x02_u8])
+      b = v.bytes
+      b.should eq(Bytes[0xAC_u8, 0x02_u8])
     end
 
     it "encodes to multiple bytes with first byte zero" do
       v = UVarInt.new 0x0F00_u64
-      e = v.encoded
-      e.should eq(Bytes[0x80_u8, 0x1E_u8])
+      b = v.bytes
+      b.should eq(Bytes[0x80_u8, 0x1E_u8])
     end
   end
 
@@ -127,8 +127,8 @@ describe UVarInt do
       (0..100000).each do
         n = Random.rand(0..0x7FFFFFFF).to_u64
         v = UVarInt.new n
-        d = v.decoded
-        d.should eq(n)
+        u = v.uint
+        u.should eq(n)
       end
     end
 
@@ -142,8 +142,8 @@ describe UVarInt do
 
       bigs.each do |n|
         v = UVarInt.new n
-        d = v.decoded
-        d.should eq(n)
+        u = v.uint
+        u.should eq(n)
       end
     end
 
@@ -154,8 +154,8 @@ describe UVarInt do
         lower = Random.rand(max_u32).to_u64
         n = upper + lower
         v = UVarInt.new n
-        d = v.decoded
-        d.should eq(n)
+        u = v.uint
+        u.should eq(n)
       end
     end
   end

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -122,39 +122,41 @@ describe UVarInt do
     end
   end
 
-  it "encodes and decodes random values" do
-    (0..100000).each do
-      n = Random.rand(0..0x7FFFFFFF).to_u64
-      v = UVarInt.new n
-      d = v.decoded
-      d.should eq(n)
-    end
-  end
-
-  it "encodes and decodes big integers" do
-    bigs = [] of UInt64
-    (32..53).each do |i|
-      n = (2 ** i).to_u64
-      bigs << n - 1
-      bigs << n
+  describe "fuzzing" do
+    it "encodes and decodes random values" do
+      (0..100000).each do
+        n = Random.rand(0..0x7FFFFFFF).to_u64
+        v = UVarInt.new n
+        d = v.decoded
+        d.should eq(n)
+      end
     end
 
-    bigs.each do |n|
-      v = UVarInt.new n
-      d = v.decoded
-      d.should eq(n)
-    end
-  end
+    it "encodes and decodes big integers" do
+      bigs = [] of UInt64
+      (32..53).each do |i|
+        n = (2 ** i).to_u64
+        bigs << n - 1
+        bigs << n
+      end
 
-  it "encodes and decodes really big integers" do
-    max_u32 = 0_u32..0xFFFFFFFF_u32
-    (0..100000).each do
-      upper = Random.rand(max_u32).to_u64 << 32
-      lower = Random.rand(max_u32).to_u64
-      n = upper + lower
-      v = UVarInt.new n
-      d = v.decoded
-      d.should eq(n)
+      bigs.each do |n|
+        v = UVarInt.new n
+        d = v.decoded
+        d.should eq(n)
+      end
+    end
+
+    it "encodes and decodes really big integers" do
+      max_u32 = 0_u32..0xFFFFFFFF_u32
+      (0..100000).each do
+        upper = Random.rand(max_u32).to_u64 << 32
+        lower = Random.rand(max_u32).to_u64
+        n = upper + lower
+        v = UVarInt.new n
+        d = v.decoded
+        d.should eq(n)
+      end
     end
   end
 end

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -38,43 +38,43 @@ describe UVarInt do
     it "handles arrays" do
       a = [0xAC_u8, 0x02_u8]
       v = UVarInt.new a
-      u = v.uint
-      u.should eq(300)
+      i = v.to_big_i
+      i.should eq(300)
     end
 
     it "handles deques" do
       d = Deque{0xAC_u8, 0x02_u8}
       v = UVarInt.new d
-      u = v.uint
-      u.should eq(300)
+      i = v.to_big_i
+      i.should eq(300)
     end
 
     it "handles static arrays" do
       s = StaticArray[0xAC_u8, 0x02_u8]
       v = UVarInt.new s
-      u = v.uint
-      u.should eq(300)
+      i = v.to_big_i
+      i.should eq(300)
     end
 
     it "handles tuples" do
       t = {0xAC_u8, 0x02_u8}
       v = UVarInt.new t
-      u = v.uint
-      u.should eq(300)
+      i = v.to_big_i
+      i.should eq(300)
     end
 
     it "handles ranges" do
       r = 0x00_u8..0x09_u8
       v = UVarInt.new r
-      u = v.uint
-      u.should eq(0)
+      i = v.to_big_i
+      i.should eq(0)
     end
 
     it "handles strings" do
       s = "abcd"
       v = UVarInt.new s
-      u = v.uint
-      u.should eq(97)
+      i = v.to_big_i
+      i.should eq(97)
     end
   end
 
@@ -91,23 +91,23 @@ describe UVarInt do
       n = Random.rand(0..0x7F).to_u8
       b = Bytes[n]
       v = UVarInt.new b
-      u = v.uint
-      u.should eq(n)
+      i = v.to_big_i
+      i.should eq(n)
     end
 
     it "decodes multiple bytes" do
       b = Bytes[0xAC_u8, 0x02_u8]
       v = UVarInt.new b
-      u = v.uint
-      u.should eq(300)
+      i = v.to_big_i
+      i.should eq(300)
     end
 
     it "decodes multiple bytes with zero" do
       n = Random.rand(0x7F).to_u8
       b = Bytes[0x80_u8, n]
       v = UVarInt.new b
-      u = v.uint
-      u.should eq(n.to_u64 << 7)
+      i = v.to_big_i
+      i.should eq(n.to_u64 << 7)
     end
   end
 
@@ -133,7 +133,7 @@ describe UVarInt do
   end
 
   describe "to_s" do
-    it "returns self.uint.to_s" do
+    it "returns self.bigint.to_s" do
       v = UVarInt.new 300_u64
       s = v.to_s 16
       s.should eq("12c")
@@ -153,8 +153,8 @@ describe UVarInt do
       (0..100000).each do
         n = Random.rand(0..0x7FFFFFFF).to_u64
         v = UVarInt.new n
-        u = v.uint
-        u.should eq(n)
+        i = v.to_big_i
+        i.should eq(n)
       end
     end
 
@@ -168,8 +168,8 @@ describe UVarInt do
 
       bigs.each do |n|
         v = UVarInt.new n
-        u = v.uint
-        u.should eq(n)
+        i = v.to_big_i
+        i.should eq(n)
       end
     end
 
@@ -180,8 +180,8 @@ describe UVarInt do
         lower = Random.rand(max_u32).to_u64
         n = upper + lower
         v = UVarInt.new n
-        u = v.uint
-        u.should eq(n)
+        i = v.to_big_i
+        i.should eq(n)
       end
     end
   end

--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -71,10 +71,10 @@ describe UVarInt do
     end
 
     it "handles strings" do
-      s = "abcd"
+      s = "34"
       v = UVarInt.new s
       i = v.to_big_i
-      i.should eq(97)
+      i.should eq(52)
     end
   end
 

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -16,12 +16,13 @@ struct UVarInt
   end
 
   def initialize(bytes : Bytes)
+    raise ArgumentError.new "cannot initialize with more than 10 bytes" if bytes.size > 10
     @encoded = bytes
     @decoded = decode bytes
   end
 
-  def initialize(en : Enumerable(UInt8))
-    raise Exception.new "overflow" if en.size >= 10
+  def initialize(en : Indexable(UInt8))
+    raise ArgumentError.new "cannot initialize with more than 10 bytes" if en.size > 10
     bytes = Bytes.new(en.size) { |i| en[i] }
     @encoded = bytes
     @decoded = decode bytes

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -46,14 +46,17 @@ struct UVarInt
     @bytes = encode uint
   end
 
+  def initialize(uint : BigInt)
+    @uint = uint.to_big_i
+    @bytes = encode uint
+  end
+
   def initialize(bytes : Bytes)
-    raise ArgumentError.new "cannot initialize with more than 10 bytes" if bytes.size > 10
     @bytes = bytes
     @uint = decode bytes
   end
 
   def initialize(en : Enumerable(UInt8))
-    raise ArgumentError.new "cannot initialize with more than 10 bytes" if en.size > 10
     arr = en.to_a
     bytes = Bytes.new(arr.to_unsafe, arr.size)
     @bytes = bytes
@@ -61,7 +64,6 @@ struct UVarInt
   end
 
   def initialize(str : String)
-    raise ArgumentError.new "cannot initialize with more than 10 bytes" if str.size > 10
     arr = str.bytes
     bytes = Bytes.new(arr.to_unsafe, arr.size)
     @bytes = bytes

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -10,9 +10,9 @@ struct UVarInt
   @encoded : Bytes
   @decoded : UInt64
 
-  def initialize(int : Int::Unsigned)
-    @decoded = int.to_u64
-    @encoded = encode @decoded
+  def initialize(uint : Int::Unsigned)
+    @decoded = uint.to_u64
+    @encoded = encode uint
   end
 
   def initialize(bytes : Bytes)
@@ -36,9 +36,8 @@ struct UVarInt
     @decoded
   end
 
-  # encode encodes a UInt64 into a UVarInt,
-  # which is an Array of UInt8's.
-  private def encode(n : UInt64) : Bytes
+  # Encodes an Int::Unsined into a Bytes slice.
+  private def encode(n : Int::Unsigned) : Bytes
     ptr = Pointer(UInt8).malloc 10
     i = 0
     while n >= MSB
@@ -50,7 +49,7 @@ struct UVarInt
     Bytes.new(ptr, i + 1)
   end
 
-  # decode decodes enumerable bytes into a UInt64.
+  # Decodes enumerable bytes into a UInt64.
   # If the enumeration is longer thar 10 bytes,
   # then an overflow exception is raised.
   private def decode(bytes : Bytes) : UInt64

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -3,9 +3,6 @@ require "./uvarint/*"
 # This module is based on the varint implementation in the Go programming
 # language. See: https://golang.org/src/encoding/binary/varint.go
 
-MSB = 0x80_u8  # 10000000
-REST = 0x7F_u8 # 01111111
-
 struct UVarInt
   @encoded : Bytes
   @decoded : UInt64
@@ -41,8 +38,8 @@ struct UVarInt
   private def encode(n : Int::Unsigned) : Bytes
     ptr = Pointer(UInt8).malloc 10
     i = 0
-    while n >= MSB
-      ptr[i] = n.to_u8 | MSB
+    while n >= 0x80_u8
+      ptr[i] = n.to_u8 | 0x80_u8
       i += 1
       n = n >> 7
     end
@@ -57,13 +54,13 @@ struct UVarInt
     x = 0_u64
     s = 0
     bytes.each_with_index do |b, i|
-      if b < MSB
+      if b < 0x80_u8
         if i > 9 || i == 9 && b > 1
-          raise Exception.new("overflow")
+          raise Exception.new "overflow"
         end
         return x | (b.to_u64 << s)
       end
-      x |= (b & REST).to_u64 << s
+      x |= (b & 0x7F_u8).to_u64 << s
       s += 7
     end
     0_u64

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -39,48 +39,48 @@ end
 
 struct UVarInt
   @bytes : Bytes
-  @uint : BigInt
+  @bigint : BigInt
 
-  def initialize(uint : Int::Unsigned)
-    @uint = uint.to_big_i
-    @bytes = encode uint
+  def initialize(int : Int::Unsigned)
+    @bigint = int.to_big_i
+    @bytes = encode int
   end
 
-  def initialize(uint : BigInt)
-    @uint = uint.to_big_i
-    @bytes = encode uint
+  def initialize(int : BigInt)
+    @bigint = int.to_big_i
+    @bytes = encode int
   end
 
   def initialize(bytes : Bytes)
     @bytes = bytes
-    @uint = decode bytes
+    @bigint = decode bytes
   end
 
   def initialize(en : Enumerable(UInt8))
     arr = en.to_a
     bytes = Bytes.new(arr.to_unsafe, arr.size)
     @bytes = bytes
-    @uint = decode bytes
+    @bigint = decode bytes
   end
 
   def initialize(str : String)
     arr = str.bytes
     bytes = Bytes.new(arr.to_unsafe, arr.size)
     @bytes = bytes
-    @uint = decode bytes
+    @bigint = decode bytes
   end
 
-  # Accessors
+  # Accessor
   def bytes
     @bytes
   end
 
-  def uint
-    @uint
+  def to_big_i
+    @bigint
   end
 
   def to_s(base : Int32)
-    @uint.to_s base
+    @bigint.to_s base
   end
 
   def hexstring
@@ -93,12 +93,20 @@ struct UVarInt
   end
 
   {% begin %}
-    {% for opt in %w(% * ** + - / << <=> === >>) %}
+
+    # for the following operators, define a method
+    # that performs that operation on both operads'
+    # int values, and returns a new UVarInt with
+    # the new value
+    {% for opt in %w(% & * ** + - / << <=> === >> ^) %}
       def {{opt.id}}(other : UVarInt) : UVarInt
-        UVarInt.new(@uint {{opt.id}} other.uint)
+        UVarInt.new(@bigint {{opt.id}} other.to_big_i)
       end
     {% end %}
 
+    # for the following name-type pairs, define a method
+    # that is mapped to the method of the same name on
+    # the internal BigInt value
     {% for name, type in {
         to_i:   Int32,   to_u:   UInt32,  to_f:   Float64,
         to_i8:  Int8,    to_i16: Int16,   to_i32: Int32,  to_i64: Int64,
@@ -107,7 +115,7 @@ struct UVarInt
     } %}
       # Returns *self* converted to {{type}}.
       def {{name.id}} : {{type}}
-        @uint.{{name.id}}
+        @bigint.{{name.id}}
       end
     {% end %}
   {% end %}

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -74,4 +74,24 @@ struct UVarInt
   def decoded
     @decoded
   end
+
+  {% begin %}
+    {% for opt in %w(% * ** + - / << <=> === >>) %}
+      def {{opt.id}}(other : UVarInt) : UInt64
+        @decoded {{opt.id}} other.decoded
+      end
+    {% end %}
+
+    {% for name, type in {
+        to_i: Int32, to_u: UInt32, to_f: Float64,
+        to_i8: Int8, to_i16: Int16, to_i32: Int32, to_i64: Int64,
+        to_u8: UInt8, to_u16: UInt16, to_u32: UInt32, to_u64: UInt64,
+        to_f32: Float32, to_f64: Float64,
+    } %}
+      # Returns *self* converted to {{type}}.
+      def {{name.id}} : {{type}}
+        @decoded.{{name.id}}
+      end
+    {% end %}
+  {% end %}
 end

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -36,49 +36,49 @@ private def decode(bytes : Bytes) : UInt64
 end
 
 struct UVarInt
-  @encoded : Bytes
-  @decoded : UInt64
+  @bytes : Bytes
+  @uint : UInt64
 
   def initialize(uint : Int::Unsigned)
-    @decoded = uint.to_u64
-    @encoded = encode uint
+    @uint = uint.to_u64
+    @bytes = encode uint
   end
 
   def initialize(bytes : Bytes)
     raise ArgumentError.new "cannot initialize with more than 10 bytes" if bytes.size > 10
-    @encoded = bytes
-    @decoded = decode bytes
+    @bytes = bytes
+    @uint = decode bytes
   end
 
   def initialize(en : Enumerable(UInt8))
     raise ArgumentError.new "cannot initialize with more than 10 bytes" if en.size > 10
     arr = en.to_a
     bytes = Bytes.new(arr.to_unsafe, arr.size)
-    @encoded = bytes
-    @decoded = decode bytes
+    @bytes = bytes
+    @uint = decode bytes
   end
 
   def initialize(str : String)
     raise ArgumentError.new "cannot initialize with more than 10 bytes" if str.size > 10
     arr = str.bytes
     bytes = Bytes.new(arr.to_unsafe, arr.size)
-    @encoded = bytes
-    @decoded = decode bytes
+    @bytes = bytes
+    @uint = decode bytes
   end
 
   # Accessors
-  def encoded
-    @encoded
+  def bytes
+    @bytes
   end
 
-  def decoded
-    @decoded
+  def uint
+    @uint
   end
 
   {% begin %}
     {% for opt in %w(% * ** + - / << <=> === >>) %}
       def {{opt.id}}(other : UVarInt) : UInt64
-        @decoded {{opt.id}} other.decoded
+        @uint {{opt.id}} other.uint
       end
     {% end %}
 
@@ -90,7 +90,7 @@ struct UVarInt
     } %}
       # Returns *self* converted to {{type}}.
       def {{name.id}} : {{type}}
-        @decoded.{{name.id}}
+        @uint.{{name.id}}
       end
     {% end %}
   {% end %}

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -95,12 +95,22 @@ struct UVarInt
   {% begin %}
 
     # for the following operators, define a method
-    # that performs that operation on both operads'
-    # int values, and returns a new UVarInt with
-    # the new value
-    {% for opt in %w(% & * ** + - / << <=> === >> ^) %}
-      def {{opt.id}}(other : UVarInt) : UVarInt
-        UVarInt.new(@bigint {{opt.id}} other.to_big_i)
+    # that performs that mathematical operation on
+    # both operands' int values, and returns a new
+    # UVarInt with the new value
+    {% for op in %w(% & * ** + - / << >> ^) %}
+      def {{op.id}}(other : UVarInt) : UVarInt
+        UVarInt.new(@bigint {{op.id}} other.to_big_i)
+      end
+    {% end %}
+
+
+    # for the following operators, define a method
+    # that performs the logical operation on both
+    # operands' int values, and returns a boolean value
+    {% for op in %w(< <= <=> == > >=) %}
+      def {{op.id}}(other : UVarInt)
+        @bigint {{op.id}} other.to_big_i
       end
     {% end %}
 

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -94,8 +94,8 @@ struct UVarInt
 
   {% begin %}
     {% for opt in %w(% * ** + - / << <=> === >>) %}
-      def {{opt.id}}(other : UVarInt) : UInt64
-        @uint {{opt.id}} other.uint
+      def {{opt.id}}(other : UVarInt) : UVarInt
+        UVarInt.new(@uint {{opt.id}} other.uint)
       end
     {% end %}
 

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -88,12 +88,8 @@ struct UVarInt
   end
 
   macro [](*args)
-    {% if args.size > 10 %}
-      raise ArgumentError.new "cannot initialize with more than 10 bytes"
-    {% else %}
-      %bytes = Bytes[{{*args}}]
-      UVarInt.new %bytes
-    {% end %}
+    %bytes = Bytes[{{*args}}]
+    UVarInt.new %bytes
   end
 
   {% begin %}

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -9,7 +9,7 @@ private MSB = 0x80_u8
 private REST = 0x7F_u8
 private ZERO = 0.to_big_i
 
-# Encodes an Int::Unsined into a Bytes slice.
+# Encodes an Int::Unsigned into a Bytes slice.
 private def encode(n : Int::Unsigned | BigInt) : Bytes
   arr = [] of UInt8
   while n >= MSB
@@ -22,8 +22,6 @@ private def encode(n : Int::Unsigned | BigInt) : Bytes
 end
 
 # Decodes enumerable bytes into a BigInt.
-# If the enumeration is longer thar 10 bytes,
-# then an overflow exception is raised.
 private def decode(bytes : Bytes) : BigInt
   x = ZERO
   s = 0

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -18,9 +18,18 @@ struct UVarInt
     @decoded = decode bytes
   end
 
-  def initialize(en : Indexable(UInt8))
+  def initialize(en : Enumerable(UInt8))
     raise ArgumentError.new "cannot initialize with more than 10 bytes" if en.size > 10
-    bytes = Bytes.new(en.size) { |i| en[i] }
+    arr = en.to_a
+    bytes = Bytes.new(arr.to_unsafe, arr.size)
+    @encoded = bytes
+    @decoded = decode bytes
+  end
+
+  def initialize(str : String)
+    raise ArgumentError.new "cannot initialize with more than 10 bytes" if str.size > 10
+    arr = str.bytes
+    bytes = Bytes.new(arr.to_unsafe, arr.size)
     @encoded = bytes
     @decoded = decode bytes
   end

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -100,9 +100,9 @@ struct UVarInt
     {% end %}
 
     {% for name, type in {
-        to_i: Int32, to_u: UInt32, to_f: Float64,
-        to_i8: Int8, to_i16: Int16, to_i32: Int32, to_i64: Int64,
-        to_u8: UInt8, to_u16: UInt16, to_u32: UInt32, to_u64: UInt64,
+        to_i:   Int32,   to_u:   UInt32,  to_f:   Float64,
+        to_i8:  Int8,    to_i16: Int16,   to_i32: Int32,  to_i64: Int64,
+        to_u8:  UInt8,   to_u16: UInt16,  to_u32: UInt32, to_u64: UInt64,
         to_f32: Float32, to_f64: Float64,
     } %}
       # Returns *self* converted to {{type}}.

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -64,10 +64,9 @@ struct UVarInt
   end
 
   def initialize(str : String)
-    arr = str.bytes
-    bytes = Bytes.new(arr.to_unsafe, arr.size)
-    @bytes = bytes
-    @bigint = decode bytes
+    int = str.to_u64 16
+    @bigint = int.to_big_i
+    @bytes = encode int
   end
 
   # Accessor

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -6,39 +6,66 @@ require "./uvarint/*"
 MSB = 0x80_u8  # 10000000
 REST = 0x7F_u8 # 01111111
 
-module UVarint
-  extend self
+struct UVarInt
+  @encoded : Bytes
+  @decoded : UInt64
 
-  alias UVarInt = Array(UInt8)
+  def initialize(int : Int::Unsigned)
+    @decoded = int.to_u64
+    @encoded = encode @decoded
+  end
+
+  def initialize(bytes : Bytes)
+    @encoded = bytes
+    @decoded = decode bytes
+  end
+
+  def initialize(en : Enumerable(UInt8))
+    raise Exception.new "overflow" if en.size >= 10
+    bytes = Bytes.new(en.size) { |i| en[i] }
+    @encoded = bytes
+    @decoded = decode bytes
+  end
+
+  # Accessors
+  def encoded
+    @encoded
+  end
+
+  def decoded
+    @decoded
+  end
 
   # encode encodes a UInt64 into a UVarInt,
   # which is an Array of UInt8's.
-  def encode(n : UInt64) : UVarInt
-    buf = [] of UInt8
+  private def encode(n : UInt64) : Bytes
+    ptr = Pointer(UInt8).malloc 10
+    i = 0
     while n >= MSB
-      buf << (n.to_u8 | MSB)
+      ptr[i] = n.to_u8 | MSB
+      i += 1
       n = n >> 7
     end
-    buf << n.to_u8
-    return buf
+    ptr[i] = n.to_u8
+    Bytes.new(ptr, i + 1)
   end
 
-  # decode decodes a UVarInt into a UInt64.
-  # If the UVarInt contains more than 10 UInt8's,
+  # decode decodes enumerable bytes into a UInt64.
+  # If the enumeration is longer thar 10 bytes,
   # then an overflow exception is raised.
-  def decode(vi : UVarInt) : UInt64
+  private def decode(bytes : Bytes) : UInt64
     x = 0_u64
     s = 0
-    vi.each_with_index do |v, i|
-      if v < MSB
-        if i > 9 || i == 9 && v > 1
+    bytes.each_with_index do |b, i|
+      if b < MSB
+        if i > 9 || i == 9 && b > 1
           raise Exception.new("overflow")
         end
-        return x | (v.to_u64 << s)
+        return x | (b.to_u64 << s)
       end
-      x |= (v & REST).to_u64 << s
+      x |= (b & REST).to_u64 << s
       s += 7
     end
-    return 0_u64
+    0_u64
   end
 end

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -75,6 +75,23 @@ struct UVarInt
     @uint
   end
 
+  def to_s(base : Int32)
+    @uint.to_s base
+  end
+
+  def hexstring
+    @bytes.hexstring
+  end
+
+  macro [](*args)
+    {% if args.size > 10 %}
+      raise ArgumentError.new "cannot initialize with more than 10 bytes"
+    {% else %}
+      %bytes = Bytes[{{*args}}]
+      UVarInt.new %bytes
+    {% end %}
+  end
+
   {% begin %}
     {% for opt in %w(% * ** + - / << <=> === >>) %}
       def {{opt.id}}(other : UVarInt) : UInt64

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -45,7 +45,7 @@ struct UVarInt
   end
 
   def initialize(int : BigInt)
-    @bigint = int.to_big_i
+    @bigint = int
     @bytes = encode int
   end
 

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -3,6 +3,38 @@ require "./uvarint/*"
 # This module is based on the varint implementation in the Go programming
 # language. See: https://golang.org/src/encoding/binary/varint.go
 
+# Encodes an Int::Unsined into a Bytes slice.
+private def encode(n : Int::Unsigned) : Bytes
+  ptr = Pointer(UInt8).malloc 10
+  i = 0
+  while n >= 0x80_u8
+    ptr[i] = n.to_u8 | 0x80_u8
+    i += 1
+    n = n >> 7
+  end
+  ptr[i] = n.to_u8
+  Bytes.new(ptr, i + 1)
+end
+
+# Decodes enumerable bytes into a UInt64.
+# If the enumeration is longer thar 10 bytes,
+# then an overflow exception is raised.
+private def decode(bytes : Bytes) : UInt64
+  x = 0_u64
+  s = 0
+  bytes.each_with_index do |b, i|
+    if b < 0x80_u8
+      if i > 9 || i == 9 && b > 1
+        raise Exception.new "overflow"
+      end
+      return x | (b.to_u64 << s)
+    end
+    x |= (b & 0x7F_u8).to_u64 << s
+    s += 7
+  end
+  0_u64
+end
+
 struct UVarInt
   @encoded : Bytes
   @decoded : UInt64
@@ -41,37 +73,5 @@ struct UVarInt
 
   def decoded
     @decoded
-  end
-
-  # Encodes an Int::Unsined into a Bytes slice.
-  private def encode(n : Int::Unsigned) : Bytes
-    ptr = Pointer(UInt8).malloc 10
-    i = 0
-    while n >= 0x80_u8
-      ptr[i] = n.to_u8 | 0x80_u8
-      i += 1
-      n = n >> 7
-    end
-    ptr[i] = n.to_u8
-    Bytes.new(ptr, i + 1)
-  end
-
-  # Decodes enumerable bytes into a UInt64.
-  # If the enumeration is longer thar 10 bytes,
-  # then an overflow exception is raised.
-  private def decode(bytes : Bytes) : UInt64
-    x = 0_u64
-    s = 0
-    bytes.each_with_index do |b, i|
-      if b < 0x80_u8
-        if i > 9 || i == 9 && b > 1
-          raise Exception.new "overflow"
-        end
-        return x | (b.to_u64 << s)
-      end
-      x |= (b & 0x7F_u8).to_u64 << s
-      s += 7
-    end
-    0_u64
   end
 end


### PR DESCRIPTION
This implements `UVarInt` as a struct, which means that `UVarInt` instances are immutable. The `UVarInt` struct can be instantiated with several types and in two ways, now:
```crystal
# .new with any Int::Unsigned
a = UVarInt.new 10_u8
b = UVarInt.new 10_u32

#.new with any Enumerable(UInt8)
c = UVarInt.new [172_u8, 2_u8]
d = UVarInt.new 0x00_u8..0x09_u8
e = UVarInt.new "abcd"
# enumerable size must be less than 10
f = UVarInt.new(Array.new(20, 0_u8)) # raises ArgumentError

# [] macro, like Slice[]
g = UVarInt[172, 2] # g.uint == 300
```

Also implemented are `to_s`, `hexstring`, `to_i`, `to_u`, and basic arithmetic operations:
```
a = UVarInt[172, 2]
a.to_s 16 # => "12c"
a.hexstring # => "ac02"
b = UVarInt[172, 2]
c = a + b # c is a new UVarInt
c.to_i32 # 600_i32
c.to_u32 # 600_u32
```