### PR TITLE
Add #read and #parse constructors and tests

### DIFF
--- a/spec/uvarint_spec.cr
+++ b/spec/uvarint_spec.cr
@@ -80,38 +80,50 @@ describe UVarInt do
   end
 
   describe "read" do
-    # example multihash, the uvarint is only the first 4 characters.
+    # example multihash bytes, the uvarint is only the first 4 bytes.
     # UVarInt.read should stop after reading a complete, valid uvarint.
-    #           uvarint
-    #            vvvv
-    multihash = "b220207d0a1371550f3306532ff44520b649f8be05b72674e46fc24468ff74323ab030"
+    #              uvarint
+    #             vvvvvvvvvv
+    bytes = Bytes[0xb2, 0x20, 0x20, 0x7d, 0x0a, 0x13, 0x71, 0x55, 0x0f, 0x33, 0x06, 0x53, 0x2f,
+                  0xf4, 0x45, 0x20, 0xb6, 0x49, 0xf8, 0xbe, 0x05, 0xb7, 0x26, 0x74, 0xe4, 0x6f,
+                  0xc2, 0x44, 0x68, 0xff, 0x74, 0x32, 0x3a, 0xb0, 0x30]
 
     it "handles strings" do
-      v = UVarInt.read multihash
+      str = String.new bytes
+      v = UVarInt.read str
       h = v.hexstring
       h.should eq("b220")
     end
 
     it "handles io" do
-      # this is messy:
-      # treat every two characters as one byte, convert to an array,
-      # create a slice from that array,
-      # then create an io from that slice
-      a = multihash.each_char.in_groups_of(2).map { |e| e.join.to_u8(16) }.to_a
-      s = Slice.new(a.size) { |i| a[i] }
-      io = IO::Memory.new s
+      io = IO::Memory.new bytes
       v = UVarInt.read io
       h = v.hexstring
       h.should eq("b220")
     end
 
     it "handles byte iterators" do
-      i = multihash.each_char.in_groups_of(2).map { |e| e.join.to_u8(16) }
-      v = UVarInt.read i
+      iter = bytes.each
+      v = UVarInt.read iter
       h = v.hexstring
       h.should eq("b220")
     end
   end
+
+  describe "parse" do
+    # example multihash string, the uvarint is only the first 4 characters.
+    # UVarInt.parse should stop after reading a complete, valid uvarint.
+    #           uvarint
+    #            vvvv
+    multihash = "b220207d0a1371550f3306532ff44520b649f8be05b72674e46fc24468ff74323ab030"
+
+    it "parses a string" do
+      v = UVarInt.parse multihash
+      h = v.hexstring
+      h.should eq("b220")
+    end
+  end
+
 
   describe "[] macro" do
     it "instantiates a UVarInt with the passed bytes" do

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -36,7 +36,7 @@ private def decode(bytes : Bytes) : BigInt
 end
 
 # Decodes iterable bytes into a BigInt.
-def read_decode(iter : Iterator(UInt8)) : BigInt
+private def read_decode(iter : Iterator(UInt8)) : BigInt
   x = ZERO
   s = 0
   iter.each do |b|

--- a/src/uvarint.cr
+++ b/src/uvarint.cr
@@ -82,8 +82,7 @@ struct UVarInt
   end
 
   def self.read(str : String)
-    # 0123456789abcdef => 01 23 45 67 89 ab cd ef
-    iter = str.each_char.in_groups_of(2).map { |e| e.join.to_u8(16) }
+    iter = str.each_byte
     bigint = read_decode iter
     UVarInt.new bigint
   end
@@ -95,6 +94,13 @@ struct UVarInt
   end
 
   def self.read(iter : Iterator(UInt8))
+    bigint = read_decode iter
+    UVarInt.new bigint
+  end
+
+  def self.parse(str : String)
+    # 0123456789abcdef => 01 23 45 67 89 ab cd ef
+    iter = str.each_char.in_groups_of(2).map { |e| e.join.to_u8(16) }
     bigint = read_decode iter
     UVarInt.new bigint
   end


### PR DESCRIPTION
Fixes #4 

Adds `UVarInt.read`, which accepts a `String`, `IO`, or `Iterator(UInt8)`, and returns a `UVarInt`.
Also adds `UVarInt.parse`, which parses a string formatted in hex, and returns a `UVarInt`.